### PR TITLE
Support saving ImmutableJS types to IndexedDB

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ npm-debug.log*
 
 # Optional REPL history
 .node_repl_history
+
+# Optional Env variables
+.env

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redux-storage-engine-localforage",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Version storage with migration for redux-storage",
   "main": "build/index.js",
   "jsnext:main": "src/index.js",
@@ -32,5 +32,8 @@
   },
   "dependencies": {
     "localforage": "^1.4.0"
+  },
+  "optionalDependencies": {
+    "immutable": "^3.8.1"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,14 @@
 import localforage from 'localforage'
 
 export default (key, config = {}) => {
+  let hasImmutable
+  if ('hasImmutable' in config) {
+    hasImmutable = config.hasImmutable
+    delete config.hasImmutable
+  } else {
+    hasImmutable = false
+  }
+
   localforage.config(config)
 
   return {
@@ -9,6 +17,14 @@ export default (key, config = {}) => {
     },
 
     save (state) {
+      if (hasImmutable) {
+        const isIterable = require('immutable').Iterable.isIterable
+        for (const branch in state) {
+          if (isIterable(state[branch])) {
+            state[branch] = state[branch].toJS()
+          }
+        }
+      }
       return localforage.setItem(key, state)
     }
   }


### PR DESCRIPTION
Nice library!

I tried it and it works except for one case, it can't save [ImmutableJS](https://facebook.github.io/immutable-js/) type such as [Map](https://facebook.github.io/immutable-js/docs/#/Map) or [List](https://facebook.github.io/immutable-js/docs/#/List) to IndexedDB (tested in latest Chrome, ver. 50).

The only solution I can think of is converting the Map/List to plain JS object/array using [fromJS](https://facebook.github.io/immutable-js/docs/#/fromJS) and save the plain object/array to the storage. Then it's up to the developer to convert back the stored object/array to Map/List when loading it from storage.

This Pull Request contains my proposed solution above.
